### PR TITLE
Fixing getValidToken

### DIFF
--- a/src/ionic-auth.ts
+++ b/src/ionic-auth.ts
@@ -264,7 +264,7 @@ export class IonicAuth {
         if(token == undefined)
             throw new Error("Unable To Obtain Token - No Token Available");
 
-        if(!token.isValid){
+        if(!token.isValid()){
             token = await this.requestNewToken(token);
         }
 


### PR DESCRIPTION
It seems that parenthesis are missing in getValidToken so access token is never refreshed.